### PR TITLE
Correct files count

### DIFF
--- a/tasks/rsync.js
+++ b/tasks/rsync.js
@@ -120,7 +120,7 @@ module.exports = function (grunt) {
     // files to copy
     // save command before execute files-map wise
     var allSuccessful = true;
-    var runningChilds = files.length;
+    var runningChilds = Object.keys(files).length;
     var doneCallback = function (success) {
       runningChilds -= 1;
       if (runningChilds === 0) {


### PR DESCRIPTION
As files is an object (no length property) count wasn't being determined so async done callback was never firing, preventing multiple targets. Countdown should probably be handled in doRsync method anyway (callback fires once)
